### PR TITLE
Update wdm gem from version 0.1.0 to 0.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "middleman", "~>3.3.3"
 gem "middleman-livereload", "~> 3.1.0"
 
 # For faster file watcher updates on Windows:
-gem "wdm", "~> 0.1.0", :platforms => [:mswin, :mingw]
+gem "wdm", "~> 0.1.1", :platforms => [:mswin, :mingw]
 
 # Windows does not come with time zone data
 gem "tzinfo-data", platforms: [:mswin, :mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,7 +128,7 @@ DEPENDENCIES
   middleman (~> 3.3.3)
   middleman-livereload (~> 3.1.0)
   tzinfo-data
-  wdm (~> 0.1.0)
+  wdm (~> 0.1.1)
 
 BUNDLED WITH
    1.16.3


### PR DESCRIPTION
This upgrades the `wdm` gem to the latest version, `0.1.1`. The best way to see what changed is by looking at [the diff between the two versions][1]—unfortunately, the changelog was removed in this version, so it's a little harder to see what this means in English.

I didn't test this because I'm not on Windows, but I feel comfortable upgrading the gem given that it's a patch version. I can spin up a Windows VM and test this out, if helpful.

This partially addresses #2.

[1]: https://github.com/Maher4Ever/wdm/compare/v0.1.0..v0.1.1