### PR TITLE
Fix border loading issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Meme is a generator that Vox Media uses to create social sharing images. See wor
 * Improved initial rendering with loaded web fonts.
 * Improved cross-origin options: both for base64 images and CORS.
 * Highly (and easily!) customizable editor and theme options.
-* Watermark selector.
 
 ## Install
 

--- a/source/javascripts/main.js
+++ b/source/javascripts/main.js
@@ -26,7 +26,7 @@ MEME = {
   },
 
   init: function() {
-    this.model = new this.MemeModel(window.MEME_SETTINGS || {});
+    this.model = new this.MemeModel(window.MEME_SETTINGS);
 
     // Create renderer view:
     this.canvas = new this.MemeCanvasView({

--- a/source/javascripts/models/meme.js
+++ b/source/javascripts/models/meme.js
@@ -1,16 +1,10 @@
 /*
 * MemeModel
-* Manages rendering parameters and source image datas.
+* Manages rendering parameters and background image data.
 */
 MEME.MemeModel = Backbone.Model.extend({
   defaults: {
     aspectRatio: 'us-letter',
-    aspectRatioOpts: [
-      {text: 'US Letter (8.5x11")', value: 'us-letter'},
-      {text: 'US Flyer (11x17")', value: 'us-tabloid'},
-      {text: 'A4 (210 x 297mm)', value: 'a4'},
-      {text: 'A3 (297 x 420mm)', value: 'a3'}
-    ],
     /* backgroundColor: '',
     backgroundColorOpts: ['#ffffff', '#17292e', '#0f81e8', '#40d7d4', '#FFAB03'], */
     backgroundPosition: { x: null, y: null },
@@ -31,10 +25,6 @@ MEME.MemeModel = Backbone.Model.extend({
     websiteUrlText: 'myeventurl.org',
     height: 1060,
     imageScale: 1,
-    imageSrc: '',
-		imageSrcTabloid: '',
-		imageSrcA4: '',
-		imageSrcA3: '',
     imageOpts: '',
     overlayAlpha: 0.5,
     overlayColor: '#17292e',
@@ -48,24 +38,12 @@ MEME.MemeModel = Backbone.Model.extend({
     ],
     /*textShadow: false,
     textShadowEdit: true, */
-    watermarkAlpha: 1,
-    watermarkMaxWidthRatio: 0.2,
-    watermarkSrc: '',
-    watermarkOpts: [],
     width: 824
   },
 
-  // Initialize with custom image members used for background and watermark:
-  // These images will (sort of) behave like managed model fields.
+  // Initialize with custom image member used for the background.
+  // This image will (sort of) behave like a managed model field.
   initialize: function() {
-    this.background = new Image();
-    this.watermark = new Image();
-
-    // Set image sources to trigger "change" whenever they reload:
-    // this.background.onload = this.watermark.onload = _.bind(function() {
-    //   this.trigger('change');
-    // }, this);
-
     /**
      * // TO DO
      * Refactor above to follow the following convention
@@ -73,75 +51,23 @@ MEME.MemeModel = Backbone.Model.extend({
      * @param {String} 'change'
      * @param cb callback that handles the change detected in the Backbone extend
      */
+    this._imagesByAspectRatioName = {};
+    _.each(this.get('aspectRatioOpts'), function (aspectRatioOpt) {
+      var image = new Image();
+      image.onload = _.bind(this.trigger, this, 'imageLoaded');
+      image.src = aspectRatioOpt.backgroundImageSrc;
 
-    // Set initial image and watermark sources:
-    if (this.get('imageSrc')) this.background.src = this.get('imageSrc');
-    if (this.get('watermarkSrc')) this.setWatermarkSrc(this.get('watermarkSrc'));
+      this._imagesByAspectRatioName[aspectRatioOpt.value] = image;
+    }, this);
+  },
 
-    // Update image and watermark sources if new source URLs are set:
-		this.listenTo(this, 'change:imageSrc', function() {
-      this.background.src = this.get('imageSrc');
-      this.setImageSrc(this.get('imageSrc'));
-    });
-    this.listenTo(this, 'change:watermarkSrc', function() {
-      this.setWatermarkSrc(this.get('watermarkSrc'));
-    });
+  getBackgroundImage: function () {
+    return this._imagesByAspectRatioName[this.get('aspectRatio')];
   },
 
   // Specifies if the background image currently has data:
   hasBackground: function() {
-    return this.background.width && this.background.height;
+    var backgroundImage = this.getBackgroundImage();
+    return Boolean(backgroundImage.width && backgroundImage.height);
   },
-
-  // Loads a file stream into an image object:
-  loadFileForImage: function(file, image) {
-    var reader = new FileReader();
-    reader.onload = function() { image.src = reader.result; };
-    reader.readAsDataURL(file);
-  },
-
-  // Loads a file reference into the background image data source:
-  loadBackground: function(file) {
-    this.loadFileForImage(file, this.background);
-  },
-
-  // Loads a file reference into the watermark image data source:
-  loadWatermark: function(file) {
-    this.loadFileForImage(file, this.watermark);
-  },
-
-  // When setting a new watermark "src",
-  // this method looks through watermark options and finds the matching option.
-  // The option's "data" attribute will be set as the watermark, if defined.
-  // This is useful for avoiding cross-origin resource loading issues.
-  setWatermarkSrc: function(src) {
-    var opt = _.findWhere(this.get('watermarkOpts'), {value: src});
-    var data = (opt && opt.data) || src;
-
-    // Toggle cross-origin attribute for Data URI requests:
-    if (data.indexOf('data:') === 0) {
-      this.watermark.removeAttribute('crossorigin');
-    } else {
-      this.watermark.setAttribute('crossorigin', 'anonymous');
-    }
-
-    this.watermark.src = data;
-    this.set('watermarkSrc', src);
-  },
-
-  setImageSrc: function(src) {
-    var opt = _.findWhere(this.get('imageOpts'), {value: src});
-    var data = (opt && opt.data) || src;
-
-    // Toggle cross-origin attribute for Data URI requests:
-    if (data.indexOf('data:') === 0) {
-      this.watermark.removeAttribute('crossorigin');
-    } else {
-      this.watermark.setAttribute('crossorigin', 'anonymous');
-    }
-
-    this.background.src = data;
-    this.set('imageSrc', src);
-  }
-
 });

--- a/source/javascripts/settings.js.erb
+++ b/source/javascripts/settings.js.erb
@@ -45,10 +45,6 @@ var MEME_SETTINGS = {
 
   imageScale: 1,
   imageOpacity: 1,
-  imageSrc: '<%= image_path("strike-frame-thin-US-letter.png") %>', // default bg image url
-	imageSrcTabloid: '<%= image_path("strike-frame-thin-US-tabloid.png") %>',
-	imageSrcA4: '<%= image_path("strike-frame-thin-A4.png") %>',
-	imageSrcA3: '<%= image_path("strike-frame-thin-A3.png") %>',
   imageOpts: [
     //{text: 'Strike Frame', value:'<%= image_path("strike-frame-thin-US-letter.png") %>'},
   ],
@@ -69,25 +65,30 @@ var MEME_SETTINGS = {
 
   textShadow: false, // Text shadow toggle.
   textShadowEdit: true, // Toggles text shadow control within the editor.
-  watermarkAlpha: 1, // Opacity of watermark image.
-  watermarkMaxWidthRatio: .22 , // Maximum allowed width of watermark (percentage of total canvas width).
-
-  // Path to the watermark image source, or blank for no watermark:
-  // Alternatively, use '<%= %>' and asset_data_uri("image.png") to populate the watermark with base64 data, avoiding Cross-Origin issues.
-  watermarkSrc: (localStorage && localStorage.getItem('meme_watermark')) || '<%=  %>',
-
-  // Watermark image options: set to empty array to disable watermark picker.
-  // NOTE: only populate the "data" attributes with base64 data when concerned about Cross-Origin requests...
-  // Otherwise, just leave "data" attributes blank and allow images to load from your server.
-  watermarkOpts: [],
 
   width: 755, // Canvas rendering width.
   // width: 755 // Canvas rendering width.
   aspectRatio: 'us-letter',
   aspectRatioOpts: [
-    {text: 'US Letter (8.5x11")', value: 'us-letter'},
-    {text: 'US Flyer (11x17")', value: 'us-tabloid'},
-    {text: 'A4 (210 x 297mm)', value: 'a4'},
-    {text: 'A3 (297 x 420mm)', value: 'a3'}
+    {
+      text: 'US Letter (8.5x11")',
+      value: 'us-letter',
+      backgroundImageSrc: '<%= image_path("strike-frame-thin-US-letter.png") %>'
+    },
+    {
+      text: 'US Flyer (11x17")',
+      value: 'us-tabloid',
+      backgroundImageSrc: '<%= image_path("strike-frame-thin-US-tabloid.png") %>'
+    },
+    {
+      text: 'A4 (210 x 297mm)',
+      value: 'a4',
+      backgroundImageSrc: '<%= image_path("strike-frame-thin-A4.png") %>'
+    },
+    {
+      text: 'A3 (297 x 420mm)',
+      value: 'a3',
+      backgroundImageSrc: '<%= image_path("strike-frame-thin-A3.png") %>'
+    }
   ]
 };

--- a/source/javascripts/views/meme-editor.js
+++ b/source/javascripts/views/meme-editor.js
@@ -34,9 +34,7 @@ MEME.MemeEditorView = Backbone.View.extend({
       );
     }
     // Build aspect ratio options:
-    if (d.aspectRatioOpts && d.aspectRatioOpts.length) {
-      $('#aspect-ratio').append(buildOptions(d.aspectRatioOpts)).show();
-    }
+    $('#aspect-ratio').append(buildOptions(d.aspectRatioOpts)).show();
 
     if (d.textShadowEdit) {
       $('#text-shadow').parent().show();
@@ -74,10 +72,6 @@ MEME.MemeEditorView = Backbone.View.extend({
     // Build bg image options:
     if (d.imageOpts && d.imageOpts.length) {
       $('#image').append(buildOptions(d.imageOpts)).show();
-    }
-    // Build watermark options:
-    if (d.watermarkOpts && d.watermarkOpts.length) {
-      $('#watermark').append(buildOptions(d.watermarkOpts)).show();
     }
 
     // Build overlay color options:
@@ -129,8 +123,6 @@ MEME.MemeEditorView = Backbone.View.extend({
     this.$('#website-url').val(d.websiteUrlText);
 
     this.$('#aspect-ratio').val(d.aspectRatio);
-    this.$('#watermark').val(d.watermarkSrc);
-    this.$("#watermark-alpha").val(d.watermarkAlpha);
     // this.$('#image-scale').val(d.imageScale);
     this.$('#image').val(d.imageSrc);
 
@@ -159,29 +151,15 @@ MEME.MemeEditorView = Backbone.View.extend({
     'change #title-font-size': 'onFontSize',
     'change #font-family': 'onFontFamily',
     'change [name="font-color"]': "onFontColor",
-    "change #watermark": "onWatermark",
-    "change #watermark-alpha": "onWatermarkAlpha",
     "change #text-align": "onTextAlign",
     "change #text-shadow": "onTextShadow",
     "change #overlay-alpha": "onOverlayAlpha",
     'change [name="overlay"]': "onOverlayColor",
     'change [name="background-color"]': "onBackgroundColor",
-    "dragover #dropzone": "onZoneOver",
-    "dragleave #dropzone": "onZoneOut",
-    "drop #dropzone": "onZoneDrop",
-    'change #loadinput': 'onFileLoad'
   },
 
   onCredit: function() {
     this.model.set('creditText', this.$('#credit').val());
-  },
-
-  onFileLoad: function(evt){
-    input = evt.target
-    if (input.files && input.files[0]) {
-      this.model.loadBackground(input.files[0]);
-      this.$('#dropzone').removeClass('pulse');
-    }
   },
 
   onHeadline: function() {
@@ -226,14 +204,6 @@ MEME.MemeEditorView = Backbone.View.extend({
     this.model.set('imageSrc', this.$('#image').val());
     if (localStorage) localStorage.setItem('meme_image', this.$('#image').val());
   },
-  onWatermark: function() {
-    this.model.set('watermarkSrc', this.$('#watermark').val());
-    if (localStorage) localStorage.setItem('meme_watermark', this.$('#watermark').val());
-  },
-
-  onWatermarkAlpha: function() {
-    this.model.set("watermarkAlpha", this.$("#watermark-alpha").val());
-  },
 
   onScale: function() {
     this.model.set('imageScale', this.$('#image-scale').val());
@@ -256,24 +226,4 @@ MEME.MemeEditorView = Backbone.View.extend({
     evt.preventDefault();
     return evt.originalEvent.dataTransfer || null;
   },
-
-  onZoneOver: function(evt) {
-    var dataTransfer = this.getDataTransfer(evt);
-    if (dataTransfer) {
-      dataTransfer.dropEffect = 'copy';
-      this.$('#dropzone').addClass('pulse');
-    }
-  },
-
-  onZoneOut: function(evt) {
-    this.$('#dropzone').removeClass('pulse');
-  },
-
-  onZoneDrop: function(evt) {
-    var dataTransfer = this.getDataTransfer(evt);
-    if (dataTransfer) {
-      this.model.loadBackground(dataTransfer.files[0]);
-      this.$('#dropzone').removeClass('pulse');
-    }
-  }
 });

--- a/source/partials/_editor.html.erb
+++ b/source/partials/_editor.html.erb
@@ -7,65 +7,6 @@
     <select class="aspect-ratio" id="aspect-ratio">
       <option value="" disabled>Paper Size</option>
     </select>
-
-    <!-- <h3><label for="image">Background Image</label></h3>
-    <select class="image" id="image">
-      <option value="" disabled>Select a background image...</option>
-    </select> -->
-
-    <!--<h3>Image File</h3>
-    <div class="dropzone" id="dropzone">Drop Image Here</div>
-    <input type="file" id="loadinput"></input>
-
-
-    <div class="image-attribution">
-      <h3><label for="credit">Image Credit:</label></h3>
-      <input id="credit" name="credit" type="text" placeholder="Source:" value="">
-    </div>
-
-    <div class="image-sources">
-      <h4 style="display:none;">Image Sources:</h4>
-      <ul>
-        <li><a class="flickr" href="https://flickr.com/350org/" target="_blank" title="350's organizational collection of photos.">350 Flickr</a></li>
-        <li><a class="climate-visuals" href="https://www.climatevisuals.org/images?f%5B0%5D=usage%3ACreative%20Commons" target="_blank" title="Creative commons-licensed climate-related photos.">Climate Visuals</a></li>
-        <li><a class="google" href="https://www.google.com/search?q=%20&tbm=isch&tbs=sur:f" target="_blank" title="Google Image Search for images licensed for noncommercial reuse.">Google Image Search</a></li>
-        <li><a class="unsplash" href="https://unsplash.com/" target="_blank" title="Free stock photos">Unsplash</a></li>
-
-      </ul>
-    </div>
-
-
-
-
-
-    <h3><label for="image-scale">Resize image</label></h3>
-    <input id="image-scale" type="range" max="4" min=".01" step=".01" value="1">
-    <p class="text-small"><small>Click and drag the image in the preview to reposition it.</small></p>
-
-    <h3><label for="overlay-alpha">Overlay Transparency</label></h3>
-    <input id="overlay-alpha" type="range" max="1" min=".01" step=".01" value="1">
-
-    <div class="m-editor__overlay" id="overlay">
-      <h3>Overlay Color</h3>
-      <ul class="checkbox-group">
-        <li><label><input type="radio" name="overlay" value=""> None</label></li>
-      </ul>
-    </div>
-
-    <div class="m-editor__backgroundcolor" id="background-color">
-      <h3>Background Color</h3>
-      <ul class="checkbox-group">
-        <li><label><input type="radio" name="background-color" value=""> None</label></li>
-      </ul>
-    </div> -->
-
-    <!-- <select class="watermark" id="watermark">
-      <option value="" disabled>Select a watermark</option>
-    </select>
-
-    <h2><label for="watermark-alpha">Watermark Transparency</label></h2>
-    <input id="watermark-alpha" type="range" max="1" min=".01" step=".01" value="1">
-  -->
   </div>
 
   <div id="editor-options-text" class="content-pane editor-options-section">

--- a/source/stylesheets/modules/_m-editor.scss
+++ b/source/stylesheets/modules/_m-editor.scss
@@ -78,8 +78,7 @@ $m: '.m-editor';
   .font-size,
   .font-family,
   .overlay-alpha,
-  .text-shadow,
-  .watermark {
+  .text-shadow {
     display: none;
   }
 


### PR DESCRIPTION
*tl;dr: before this change, the poster borders would sometimes disappear and reappear randomly—no longer! See #3 for more.*

Three things I learned while working on this change that are relevant here:

1. The paper size (like US Letter, or A4) is called `aspectRatio` internally.

2. The poster borders are implemented as background images, one per aspect ratio.

3. There are several "dormant" features, such as the ability to add a watermark to the result. They are dormant because their code paths are in the source code but unused.

Borders would sometimes fail to show up, which was because the background image sometimes failed to load properly. This change:

1. Loads all 4 border images upfront. The border can still be missing while these images load (probably most noticeable on page load or on a slow connection), but the canvas will re-render as soon as any image loads.

2. Removes the unused image upload and watermark features. I was changing a few things about how images worked and didn't want to do it twice. Doing this let me remove a bunch of things that were only used by these code paths.

3. Each aspect ratio has a different border image; this change makes that relationship more explicit. (In the code, that means I moved the border image URL into `aspectRatioOpts`.) That also meant that the border image URL is computed from the aspect ratio instead of being a separate stored property that needs to be kept in sync.

Closes #3.